### PR TITLE
Fix "Zoom to Location" error

### DIFF
--- a/src/components/hub-compass-map/hub-compass-map.tsx
+++ b/src/components/hub-compass-map/hub-compass-map.tsx
@@ -169,19 +169,37 @@ export class HubCompassMap {
 
   @Watch('center')
   async updateCenter(newCenter) {
-    this.mapView.goTo({
-      center: newCenter,
-      zoom: this.zoom
-    });
-    const graphic = this.createGraphic(this.mapView.center);
-    this.mapView.graphics.addMany([graphic], 0);
+    if(this.mapView) {
+
+      // mapView may exist but not be ready - like in the case of updating the center immediately. 
+      // so we should wait till it's ready.
+      await reactiveUtils.once(() => this.mapView.ready === true)
+
+      this.mapView.goTo({
+        center: newCenter,
+        zoom: this.zoom
+      });
+      const graphic = this.createGraphic(this.mapView.center);
+      this.mapView.graphics.addMany([graphic], 0);
+    } else {
+      console.warn("Trying to goto but no map created yet.")
+    }
   }
   @Watch('zoom')
   async updateZoom(newZoom) {
-    this.mapView.goTo({
-      center: this.center,
-      zoom: newZoom
-    });
+    if(this.mapView) {
+
+      // mapView may exist but not be ready - like in the case of updating the center immediately. 
+      // so we should wait till it's ready.
+      await reactiveUtils.once(() => this.mapView.ready === true)
+
+      this.mapView.goTo({
+        center: this.center,
+        zoom: newZoom
+      });
+    } else {
+      console.warn('Trying to zoom to but no map created yet.');
+    }
   }
 
   /**

--- a/src/index.html
+++ b/src/index.html
@@ -112,7 +112,7 @@
     componentEl.showSearch = true;
     componentEl.showTable = true;
     componentEl.showServiceAreas = false;
-    componentEl.basemap = "gray-vector";
+    componentEl.basemap = "arcgis-topographic";
 
     function moveMap(center, zoom) {
       componentEl.center = center;

--- a/src/index.html
+++ b/src/index.html
@@ -112,7 +112,7 @@
     componentEl.showSearch = true;
     componentEl.showTable = true;
     componentEl.showServiceAreas = false;
-    componentEl.basemap = "arcgis-topographic";
+    componentEl.basemap = "gray-vector";
 
     function moveMap(center, zoom) {
       componentEl.center = center;


### PR DESCRIPTION
After switching to the latest version of the ArcGIS Maps SDK for JavaScript in #2, in `hub-compass-chat` we are not able to use the "Zoom to Location" button. I think this is happening because we're calling `.goto` before the `mapView` is ready. So this update changes the code to wait until the `mapView` is ready.